### PR TITLE
ensure -lrt comes after -lmirage-clock-unix_stubs

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -806,5 +806,5 @@ let system_support_lib = match os with
 | _ -> []
 
 let () =
-  flag ["link"] (S (system_support_lib));
+        flag ["link"; "ocaml"; "native"; "unix"] (S ([A "-cclib"; A "-lmirage-clock-unix_stubs"] @ system_support_lib));
   Ocamlbuild_plugin.dispatch dispatch_default

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -806,5 +806,5 @@ let system_support_lib = match os with
 | _ -> []
 
 let () =
-        flag ["link"; "ocaml"; "native"; "unix"] (S ([A "-cclib"; A "-lmirage-clock-unix_stubs"] @ system_support_lib));
+        flag ["link"; "ocaml"; "native"; "use_mirage-clock-unix"] (S ([A "-cclib"; A "-lmirage-clock-unix_stubs"] @ system_support_lib));
   Ocamlbuild_plugin.dispatch dispatch_default


### PR DESCRIPTION
I _believe_ this should fix the build order issue uncovered by @mato in #10 ; the output of `ocamlfind ocamlopt` now has `-lmirage-clock-unix_stubs` before `-lrt`.
