### PR TITLE
mirage-clock-unix: Fix integer overflow on 32bit

### DIFF
--- a/unix/clock_stubs.c
+++ b/unix/clock_stubs.c
@@ -51,8 +51,8 @@ CAMLprim value ocaml_posix_clock_gettime_s_ns (value unit)
   struct timeval now;
   if (gettimeofday(&now, NULL) == -1) { caml_failwith("gettimeofday"); }
 
-  Store_field(time_s_ns, 0, Val_int(now.tv_sec));
-  Store_field(time_s_ns, 1, Val_long(now.tv_usec * 1000L));
+  Store_field(time_s_ns, 0, caml_copy_int64(now.tv_sec));
+  Store_field(time_s_ns, 1, caml_copy_int64(now.tv_usec * 1000L));
 
   CAMLreturn (time_s_ns);
 }
@@ -94,8 +94,8 @@ CAMLprim value ocaml_posix_clock_gettime_s_ns (value unit)
   struct timespec now;
   if (clock_gettime(CLOCK_REALTIME, &now) == -1) { caml_failwith("clock_gettime(CLOCK_REALTIME, ..)"); }
 
-  Store_field(time_s_ns, 0, Val_int(now.tv_sec));
-  Store_field(time_s_ns, 1, Val_long(now.tv_nsec));
+  Store_field(time_s_ns, 0, caml_copy_int64(now.tv_sec));
+  Store_field(time_s_ns, 1, caml_copy_int64(now.tv_nsec));
 
   CAMLreturn (time_s_ns);
 }
@@ -199,8 +199,8 @@ CAMLprim value ocaml_posix_clock_gettime_s_ns (value unit)
   lft.HighPart = ft.dwHighDateTime;
   t = lft.QuadPart - DELTA_EPOCH_IN_100NS;
 
-  Store_field(time_s_ns, 0, Val_int(t / POW10_7));
-  Store_field(time_s_ns, 1, Val_long(((int) (t % POW10_7)) * 100));
+  Store_field(time_s_ns, 0, caml_copy_int64(t / POW10_7));
+  Store_field(time_s_ns, 1, caml_copy_int64(((int) (t % POW10_7)) * 100));
 
   CAMLreturn (time_s_ns);
 }
@@ -229,8 +229,8 @@ CAMLprim value ocaml_posix_clock_gettime_s_ns (value unit)
   CAMLlocal1(time_s_ns);
   time_s_ns = caml_alloc(2, 0);
 
-  Store_field(time_s_ns, 0, Val_int(0));
-  Store_field(time_s_ns, 1, Val_long(0L));
+  Store_field(time_s_ns, 0, caml_copy_int64(0));
+  Store_field(time_s_ns, 1, caml_copy_int64(0L));
 
   CAMLreturn (time_s_ns);
 }

--- a/unix/pclock.ml
+++ b/unix/pclock.ml
@@ -21,18 +21,18 @@ type error = unit
 
 let ps_count_in_s = 1_000_000_000_000L
 
-external posix_clock_gettime_s_ns : unit -> int * int = "ocaml_posix_clock_gettime_s_ns"
+external posix_clock_gettime_s_ns : unit -> int64 * int64 = "ocaml_posix_clock_gettime_s_ns"
 
 let connect _ = Lwt.return_unit
 let disconnect _t = Lwt.return_unit
 
 let now_d_ps t =
   let secs, ns = posix_clock_gettime_s_ns () in
-  let days = secs / 86_400 in
-  let rem_s = secs mod 86_400 in
-  let frac_ps = Int64.(mul (of_int ns) 1000L) in
-  let rem_ps = Int64.(mul (of_int rem_s) ps_count_in_s) in
-  (days, (Int64.add rem_ps frac_ps))
+  let days = Int64.div secs 86_400L in
+  let rem_s = Int64.rem secs 86_400L in
+  let frac_ps = Int64.mul ns 1000L in
+  let rem_ps = Int64.mul rem_s ps_count_in_s in
+  (Int64.to_int days, (Int64.add rem_ps frac_ps))
 
 let current_tz_offset_s t =
   let now = Unix.gettimeofday () in


### PR DESCRIPTION
Use int64 and caml_copy_int64 when calling into C stubs.

I think this fixes https://github.com/mirage/mirage-clock/issues/17, though I agree with @dinosaure and others that if support for Windows can be added to `Ptime_clock` a better fix would be to use that directly in `mirage-clock-unix` and remove the considerable amount of near-duplicated code.

I've reproduced the bug and tested this fix this on an Ubuntu Xenial 32bit VM, as well as on Darwin and Xenial 64bits. I haven't tested in Windows.