### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-clock-freestanding.opam
+++ b/mirage-clock-freestanding.opam
@@ -15,7 +15,7 @@ MirageOS.
 """
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build}
+  "dune"
   "mirage-clock" {>= "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"

--- a/mirage-clock-lwt.opam
+++ b/mirage-clock-lwt.opam
@@ -13,7 +13,7 @@ the `io` type to use the Lwt concurrency monad.
 """
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build}
+  "dune"
   "mirage-clock" {>= "1.2.0"}
   "lwt"
 ]

--- a/mirage-clock-unix.opam
+++ b/mirage-clock-unix.opam
@@ -14,7 +14,7 @@ which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/b
 """
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build}
+  "dune"
   "mirage-clock" {>= "1.2.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "lwt"

--- a/mirage-clock.opam
+++ b/mirage-clock.opam
@@ -18,7 +18,7 @@ epoch.
 """
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build}
+  "dune"
   "mirage-device" {>= "1.0.0"}
 ]
 build: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.