### PR TITLE
Use implicit executable dependency for discover.exe

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -4,5 +4,4 @@
 
 (rule
  (targets cclib.sexp)
- (deps    discover.exe)
  (action  (run ./discover.exe)))


### PR DESCRIPTION
Explicit executable dependencies make dune fail in cross-compilation settings.
More info in https://github.com/ocaml/dune/issues/3917.