### PR TITLE
fix esy cross compile

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -28,11 +28,16 @@ jobs:
           echo '{
             "name": "cross-compile",
             "dependencies": {
-              "ocaml": "~4.10.1002",
-              "mirage-clock": "./mirage-clock.opam",
-              "mirage-clock-unix": "./mirage-clock-unix.opam",
-              "mirage-clock-freestanding": "./mirage-clock-freestanding.opam",
-              "reason-mobile": "github:EduardoRFS/reason-mobile:generate.json#ca7b8c8330b1b071ed1e1c1491c3ca2764907976"
+              "ocaml": "4.12.x",
+              "@opam/mirage-clock": "*",
+              "@opam/mirage-clock-unix": "*",
+              "@opam/mirage-clock-freestanding": "*",
+              "reason-mobile": "github:EduardoRFS/reason-mobile:generate.json#7ba258319b87943d2eb0d8fb84562d0afeb2d41f"
+            },
+            "resolutions": {
+              "@opam/mirage-clock": "./mirage-clock.opam",
+              "@opam/mirage-clock-unix": "./mirage-clock-unix.opam",
+              "@opam/mirage-clock-freestanding": "./mirage-clock-freestanding.opam"
             }
           }' > esy.json
 
@@ -91,11 +96,16 @@ jobs:
           echo '{
             "name": "cross-compile",
             "dependencies": {
-              "ocaml": "~4.10.1002",
-              "mirage-clock": "./mirage-clock.opam",
-              "mirage-clock-unix": "./mirage-clock-unix.opam",
-              "mirage-clock-freestanding": "./mirage-clock-freestanding.opam",
-              "reason-mobile": "github:EduardoRFS/reason-mobile:generate.json#ca7b8c8330b1b071ed1e1c1491c3ca2764907976"
+              "ocaml": "4.12.x",
+              "@opam/mirage-clock": "*",
+              "@opam/mirage-clock-unix": "*",
+              "@opam/mirage-clock-freestanding": "*",
+              "reason-mobile": "github:EduardoRFS/reason-mobile:generate.json#7ba258319b87943d2eb0d8fb84562d0afeb2d41f"
+            },
+            "resolutions": {
+              "@opam/mirage-clock": "./mirage-clock.opam",
+              "@opam/mirage-clock-unix": "./mirage-clock-unix.opam",
+              "@opam/mirage-clock-freestanding": "./mirage-clock-freestanding.opam"
             }
           }' > esy.json
 

--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -62,7 +62,6 @@ jobs:
             ios.simulator.x86_64,
             linux.musl.arm64,
             linux.musl.x86_64,
-            freebsd.x86_64,
           ]
         exclude:
           - system: ubuntu
@@ -74,8 +73,6 @@ jobs:
             target: linux.musl.arm64
           - system: macos
             target: linux.musl.x86_64
-          - system: macos
-            target: freebsd.x86_64
 
     name: Build ${{ matrix.target }} on ${{ matrix.system }}
     runs-on: ${{ matrix.system }}-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build
 .merlin
 duniverse
 *.locked
+_esy

--- a/dune
+++ b/dune
@@ -3,7 +3,7 @@
 (alias
  (name default)
  (enabled_if
-  (= %{context_name} "default"))
+  (<> %{context_name} "freestanding"))
  (deps
   (alias_rec src/all)
   (alias_rec unix/all)

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -9,5 +9,14 @@
 
 (rule
  (target clock_stubs.c)
- (deps clock_stubs.freestanding.c clock_stubs.default.c)
- (action (copy clock_stubs.%{context_name}.c %{target})))
+ (enabled_if
+  (<> %{context_name} "freestanding"))
+ (deps (:src clock_stubs.default.c))
+ (action (copy %{src} %{target})))
+
+(rule
+ (target clock_stubs.c)
+ (enabled_if
+  (= %{context_name} "freestanding"))
+ (deps (:src clock_stubs.freestanding.c))
+ (action (copy %{src} %{target})))


### PR DESCRIPTION
In a previous PR the cross compile CI was broken, so this PR fixes it and also bumps the dependencies to the latest one.