### PR TITLE
Solo5 pclock experiment

### DIFF
--- a/solo5/pclock.mli
+++ b/solo5/pclock.mli
@@ -19,3 +19,12 @@
     Clock counting time since the Unix epoch. Subject to adjustment by e.g. NTP. *)
 
 include Mirage_clock.PCLOCK
+
+val hypercall_wall_clock : unit -> int * int64
+(** [hypercall_wall_clock ()] is the current wall clock time according to the
+    hypervisor. This involves a hypercall and is slower than [now_d_ps ()], but
+    may be more accurate. *)
+
+val refresh : unit -> unit
+(** [refresh ()] does a hypercall to get the wall clock time according to the
+    host and updates the internal offset. *)


### PR DESCRIPTION
This is work in progress experimentation of moving offset calculations of the monotonic clock relative to the wall clock out of solo5 bindings into Mirage land. Related to https://github.com/Solo5/solo5/pull/550

CC/ @dinosaure 